### PR TITLE
Fix for CLI argument --project where tsconfig path may contain spaces

### DIFF
--- a/generate-report.js
+++ b/generate-report.js
@@ -29,7 +29,7 @@
     }
 
     if (config.typeCheck) {
-      cliArguments = cliArguments + ' --project ' + config.tsconfig
+      cliArguments = cliArguments + ' --project "' + config.tsconfig + '"';
     }
 
     console.info(funkyLogger.color('cyan', 'Generating TSlint report.'));


### PR DESCRIPTION
Hi there,

My tsconfig project path contains spaces and the CLI argument --project isn't enclosed in double quotes. I updated the generated-report.js file to enclose the project argument in double quotes.

Cheers
Kranthi