### PR TITLE
Fix for max buffer size filled up issue

### DIFF
--- a/generate-report.js
+++ b/generate-report.js
@@ -33,7 +33,7 @@
     }
 
     console.info(funkyLogger.color('cyan', 'Generating TSlint report.'));
-    const result = npmRun.exec('tslint' + cliArguments, { cwd: __dirname }, (error, stdout, stderr) => {
+    const result = npmRun.exec('tslint' + cliArguments, { cwd: __dirname, maxBuffer: Infinity }, (error, stdout, stderr) => {
       if (error) {
         console.error(error);
       }


### PR DESCRIPTION
Recently while using tslint-html-report in my project it failed and while debugging found it was because of buffer size, so increased the boosted the buffer size to infinity